### PR TITLE
[#12588] Add test for handling special characters in email fields

### DIFF
--- a/src/test/java/teammates/logic/api/EmailSenderTest.java
+++ b/src/test/java/teammates/logic/api/EmailSenderTest.java
@@ -97,4 +97,15 @@ public class EmailSenderTest extends BaseLogicTest {
         assertEquals(wrapper.getContent(), email.get(Email.HTMLPART));
     }
 
+    @Test
+    public void testSpecialCharactersInFields() {
+        EmailWrapper wrapper = getTypicalEmailWrapper();
+        wrapper.setSubject("Test 🚀 with special characters 🎉");
+        wrapper.setContent("<p>Content with emoji 😊 and symbols &copy;</p>");
+
+        Mail email = new SendgridService().parseToEmail(wrapper);
+        assertEquals("Test 🚀 with special characters 🎉", email.getSubject());
+        assertEquals("Content with emoji 😊 and symbols ©", email.getContent().get(0).getValue());
+    }
+
 }


### PR DESCRIPTION
Part of #12588

**Outline of Solution**

Added a new test case `testSpecialCharactersInFields` to verify the correct handling of special characters, emojis, and HTML entities in email subject and content.

- Updated EmailSenderTest with the new test method to ensure proper parsing and encoding of special characters in email fields.
- Validates UTF-8 compatibility for subjects and content with emojis and symbols.
- Focused on Sendgrid email conversion logic but extensible to other services in the future.
